### PR TITLE
Fixed suppressing exception when channel is closed

### DIFF
--- a/src/main/java/nl/jk5/mqtt/ChannelClosedException.java
+++ b/src/main/java/nl/jk5/mqtt/ChannelClosedException.java
@@ -1,0 +1,28 @@
+package nl.jk5.mqtt;
+
+/**
+ * Created by Valerii Sosliuk on 12/26/2017.
+ */
+public class ChannelClosedException extends RuntimeException {
+
+    private static final long serialVersionUID = 6266638352424706909L;
+
+    public ChannelClosedException() {
+    }
+
+    public ChannelClosedException(String message) {
+        super(message);
+    }
+
+    public ChannelClosedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ChannelClosedException(Throwable cause) {
+        super(cause);
+    }
+
+    public ChannelClosedException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/nl/jk5/mqtt/MqttClientImpl.java
+++ b/src/main/java/nl/jk5/mqtt/MqttClientImpl.java
@@ -262,8 +262,15 @@ final class MqttClientImpl implements MqttClient {
         MqttPublishMessage message = new MqttPublishMessage(fixedHeader, variableHeader, payload);
 
         MqttPendingPublish pendingPublish = new MqttPendingPublish(variableHeader.messageId(), future, payload.retain(), message, qos);
-        pendingPublish.setSent(this.sendAndFlushPacket(message) != null);
+        ChannelFuture channelFuture = this.sendAndFlushPacket(message);
 
+        if (channelFuture != null) {
+            pendingPublish.setSent(channelFuture != null);
+            if (channelFuture.cause() != null) {
+                future.setFailure(channelFuture.cause());
+                return future;
+            }
+        }
         if (pendingPublish.isSent() && pendingPublish.getQos() == MqttQoS.AT_MOST_ONCE) {
             pendingPublish.getFuture().setSuccess(null); //We don't get an ACK for QOS 0
         } else if (pendingPublish.isSent()) {
@@ -293,7 +300,7 @@ final class MqttClientImpl implements MqttClient {
         if (this.channel.isActive()) {
             return this.channel.writeAndFlush(message);
         }
-        return this.channel.newFailedFuture(new RuntimeException("Channel is closed"));
+        return this.channel.newFailedFuture(new ChannelClosedException("Channel is closed"));
     }
 
     private MqttMessageIdVariableHeader getNewMessageId() {


### PR DESCRIPTION
When channel is closed, Future was returned as success. 
Added new exception class for the caller to be able to figure out when to reconnect